### PR TITLE
Migrate to Project Rules and scaffold docs (analyze-app, generate-docs)

### DIFF
--- a/.cursor/rules/analyze-app.mdc
+++ b/.cursor/rules/analyze-app.mdc
@@ -1,0 +1,10 @@
+---
+description: Automate app analysis by running the dev server, capturing logs, and suggesting performance improvements.
+alwaysApply: false
+---
+
+When asked to analyze the app:
+1. Run `npm run dev` in the project root and wait for http://localhost:3000 to be ready.
+2. Capture and review console/server logs for warnings, errors, and slow startups.
+3. Suggest performance improvements (startup time, Prisma/DB configuration, Keystone queries/N+1, caching, indexing, environment toggles).
+

--- a/.cursor/rules/generate-docs.mdc
+++ b/.cursor/rules/generate-docs.mdc
@@ -1,0 +1,15 @@
+---
+description: Help draft documentation by extracting code comments, analyzing README.md, and generating markdown docs.
+alwaysApply: false
+---
+
+Help draft documentation by:
+- Extracting code comments from source (e.g., **/*.ts, **/*.tsx).
+- Analyzing `README.md` for canonical commands and context.
+- Generating markdown documentation to `docs/`:
+  - `OVERVIEW.md`
+  - `ARCHITECTURE.md`
+  - `OPERATIONS.md`
+
+@README.md
+

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ npm run dev
   - Database path: `./keystone.db` (override via `DATABASE_URL`)
 - Shut down cleanly: Ctrl+C in terminals running the server and tooling
 
+- Project Rules (Cursor):
+  - `@analyze-app`: runs `npm run dev`, collects console logs, and suggests performance improvements.
+  - `@generate-docs`: extracts code comments, analyzes `README.md`, and writes markdown docs to `docs/`.
+  - Note: Uses Project Rules in `.cursor/rules` (legacy `.cursorrules` is deprecated).
+
 ---
 
 ## Troubleshooting

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Architecture
+
+## System
+- Keystone app with lists (entities), access control, hooks, and Admin UI.
+- Prisma ORM with SQLite for local demo (easily switchable to other providers).
+
+## Access Control
+- Role-based permissions across lists/fields.
+- Department-level isolation and ownership checks.
+- Reviewer/approver flows enforced at list and mutation levels.
+
+## Workflows
+- Content lifecycle: Draft → Review → Approved → Published.
+- Actions gated by role and state; audit events recorded.
+
+## Data & Storage
+- SQLite file `./keystone.db` for local persistence.
+- Static assets served from `public/` (`/files`, `/images`).
+
+## Admin UI
+- Next.js-powered Keystone Admin UI on http://localhost:3000.
+- First run seeds super admin and baseline demo data.
+
+## Extensibility
+- Add/modify lists in `schema.ts` (not `schema.prisma` directly).
+- Keystone generates Prisma/GraphQL schema from `schema.ts`.
+

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,35 @@
+# Operations
+
+## Setup
+- Node v18+, `npm install`
+- Dev: `npm run dev` (wait for Admin UI to compile)
+- Build: `npm run build`, Start: `npm start`
+
+## Ports & Paths
+- App: 3000
+- Prisma Studio (if used): 5555
+- DB: `./keystone.db`
+
+## Environment
+- `DATABASE_URL="file:./keystone.db"` (default for local)
+- Safe to delete `keystone.db` to reset demo data locally
+
+## Maintenance
+- Reset DB:
+  ```bash
+  rm -f keystone.db
+  npm run dev
+  ```
+- Prisma Studio:
+  ```bash
+  DATABASE_URL="file:./keystone.db" npx prisma generate
+  DATABASE_URL="file:./keystone.db" npx prisma studio
+  ```
+
+## Troubleshooting
+- Temporary dev-loading warning from Keystone Admin build is benign if UI proceeds.
+- Port in use:
+  ```bash
+  lsof -ti :3000 | xargs kill -9
+  ```
+

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,28 @@
+# Adobe Enterprise CMS (Demo) — Overview
+
+## Purpose
+Enterprise-grade demo of DAM + CMS with RBAC, workflows, brand governance, and auditability.
+
+## Tech Stack
+- Keystone 6, TypeScript/Node.js
+- Prisma (SQLite)
+- Express (static assets)
+
+## What’s Included
+- RBAC with multiple roles and granular permissions
+- Assets: upload, review, approve, archive; tagging and ownership
+- Brand Management: multi-brand, compliance status/guidelines
+- Content Workflows: Draft → Review → Approved → Published
+- Audit & Analytics events
+- Department isolation and Q&A with tagging
+
+## How to Run
+- Install: `npm install`
+- Dev: `npm run dev` → Admin UI: http://localhost:3000
+- First-run seeds demo data, idempotent on subsequent runs
+
+## Data & Files
+- DB: SQLite at `./keystone.db` (override with `DATABASE_URL`)
+- Files: `public/files` → `/files`
+- Images: `public/images` → `/images`
+


### PR DESCRIPTION
Migrate deprecated .cursorrules to Project Rules in .cursor/rules (MDC).
Add analyze-app.mdc and generate-docs.mdc.
Create docs/OVERVIEW.md, docs/ARCHITECTURE.md, docs/OPERATIONS.md.
Update README.md to reference new rules; legacy .cursorrules deprecated.
No runtime changes; improves DX and repeatability.